### PR TITLE
fix electron app check,add 'app' floder

### DIFF
--- a/src/main/platforms/win.ts
+++ b/src/main/platforms/win.ts
@@ -95,6 +95,7 @@ function isElectronApp(installDir: string) {
       "default_app.asar",
       "app.asar",
       "app.asar.unpacked",
+      "app",
     ].some((file) => fs.existsSync(path.join(installDir, "resources", file)))
   );
 }


### PR DESCRIPTION
In an Electron application, the resources directory may not contain an asar file, but instead an app directory, such as in the case of VSCode or the Cursor code editor.